### PR TITLE
fix: fix flakiness in test com.dianping.cat.message.context.MessageIdFactoryTest#testDefaultDomainInParallel

### DIFF
--- a/cat-client/src/test/java/com/dianping/cat/message/context/MessageIdFactoryTest.java
+++ b/cat-client/src/test/java/com/dianping/cat/message/context/MessageIdFactoryTest.java
@@ -101,13 +101,17 @@ public class MessageIdFactoryTest extends ComponentTestCase {
 		}
 
 		pool.shutdown();
-		pool.awaitTermination(2000, TimeUnit.MILLISECONDS);
+		boolean finished = pool.awaitTermination(60, TimeUnit.SECONDS);
 
-		int total = threads * messagesPerThread;
+		if (finished) {
+			int total = threads * messagesPerThread;
 
-		Assert.assertEquals("Not all threads completed in time.", total, ids.size());
-		Assert.assertEquals(true, ids.contains(String.format("default-parallel-c0a81f9e-403215-%s", total - 1)));
-		Assert.assertEquals(String.format("default-parallel-c0a81f9e-403215-%s", total), factory.getNextId());
+			Assert.assertEquals("Not all threads completed in time.", total, ids.size());
+      Assert.assertTrue(ids.contains(String.format("default-parallel-c0a81f9e-403215-%s", total - 1)));
+			Assert.assertEquals(String.format("default-parallel-c0a81f9e-403215-%s", total), factory.getNextId());
+		} else {
+			Assert.fail("Threads did not finish in 60 seconds");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
This test is flaky due to the fact that the time which is provided (to shut the pool down) can be sufficient or not. It can fail to shut the pool down in the provided time (what results in a failed test)
If the code remains the way it is, it results in a flaky test which sometimes passes and might fail other times (non-deterministic behavior). 

## Solution:
I added the condition if the shutdown is finished or if it failed. Furthermore, the duration for the shutdown got increased to make sure, that it is possible to finish the process without running in a timeout. If the shutdown reaches the timeout, the test fails as intended. If the shutdown is finished successfully, the same conditions (asserts) apply as before. 

## Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
The test is deterministic and not flaky. This improves the quality of the test and reduces the time to search for the bug during future development.
